### PR TITLE
Hide overlay on click | Stop mobile preview button appearing in dashboard

### DIFF
--- a/js/mobile-preview.js
+++ b/js/mobile-preview.js
@@ -1,5 +1,12 @@
 ;(function($) {
     $( document ).ready(function() {    
+
+        var hidePreview = function() {
+            $('.mobile-preview-window').hide();
+            $('body').removeClass('in-mobile-preview');
+        };
+
+        // Show preview when link is clicked
         $('[href="#mobile-preview"]').on('click', function(){
             $('.mobile-preview-window').toggle();
             $('body').toggleClass('in-mobile-preview');
@@ -7,10 +14,11 @@
             return false;
         });
 
-        $(document).keyup(function(e) {
-            $('.mobile-preview-window').hide();
-            $('body').removeClass('in-mobile-preview');
-        });
+        // Hide preview on keyup
+        $(document).keyup(hidePreview);
+
+        // Hide preview when you click on the overlay
+        $('.mobile-preview-window').on('click', hidePreview);
 
      }); // end document ready
 

--- a/mobile-preview.php
+++ b/mobile-preview.php
@@ -12,12 +12,12 @@ class Upstatement_MobilePreview {
 
 	function __construct() {
 		$this->load_dependencies();
-		$this->add_toolbar_action();
 		$this->detect_viewed_in_iframe();
 		add_action( 'wp_footer', array($this, 'inject_html'));
 		add_action( 'admin_footer', array($this, 'inject_html'));
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_static' ) );
 		add_action( 'admin_enqueue_scripts', array($this, 'enqueue_static') );
+    add_action( 'wp_footer', array($this, 'add_toolbar_action') );
 	}
 
 	function load_dependencies() {
@@ -34,9 +34,9 @@ class Upstatement_MobilePreview {
 		$iframe_url = self::get_current_url();
 		if (is_admin()) {
 			global $post;
-			if ($post) {
-				$iframe_url = home_url('/?p='.$post->ID);
-			}
+      if ($post) {
+        $iframe_url = home_url('/?p='.$post->ID);
+      }
 		}
 		$iframe_url = add_query_arg('admin_bar', 'false', $iframe_url);
 		require_once 'mobile-preview-window.twig';


### PR DESCRIPTION
A common UI pattern is to hide modals etc, when an overlay is clicked. It feels like a lot of CMS users would be expecting this behaviour and might not know to hit the keyboard.

Second commit addresses the fact that the mobile preview button appears in the dashboard, and an error when no global $post object variable is available.
